### PR TITLE
Support Rails Engine routings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 spec/examples.txt
 coverage
+/tmp

--- a/lib/tasks/js_rails_routes.rake
+++ b/lib/tasks/js_rails_routes.rake
@@ -6,8 +6,8 @@ namespace :js do
     generator.exclude_paths = Regexp.new(ENV['exclude_paths']) if ENV['exclude_paths']
     generator.include_names = Regexp.new(ENV['include_names']) if ENV['include_names']
     generator.exclude_names = Regexp.new(ENV['exclude_names']) if ENV['exclude_names']
-    generator.path = ENV['path'] if ENV['path']
+    generator.base_path = ENV['base_path'] if ENV['base_path']
     generator.generate(task)
-    puts "Routes saved to #{generator.path}."
+    puts "Routes saved into #{generator.base_path}."
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,15 @@ class TestApp < Rails::Application
   end
 end
 
+module Admin
+  class Engine < ::Rails::Engine
+    routes.draw do
+      resources :notes
+      resources :photos
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Rails Engines routing isn't supported yet in js_rails_routes but my project is using Rails Engine's routings so I added the function to export JavaScript routes for its Rails Engine.

## Changes

### Support Rails Engines

- Add `exclude_engines` class variable
- Change a class variable name to base_path from path.
- Save the routes file each Rails Engines and `Rails.application`

I did these operation checkings.

- Install this changes with `gem 'js_rails_routes', path: '../../sachin21/js_rails_routes'`
- Execute `rails js:routes` in Rails project with Rails Engine routes.
- Confirmed it includes Rails Engine's routings.
