### PR TITLE
Support lower and upper camelcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ rake js:routes
 
 JSRailsRoutes supports several parameters:
 
-Name              | Type     | Description                                    | Default
-------------------|----------|------------------------------------------------|----------------------------------------
-`include_paths`   | `Regexp` | Paths match to the regexp are included         | `/.*/`
-`exclude_paths`   | `Regexp` | Paths match to the regexp are excluded         | `/^$/`
-`include_names`   | `Regexp` | Names match to the regexp are included         | `/.*/`
-`exclude_names`   | `Regexp` | Names match to the regexp are excluded         | `/^$/`
-`exclude_engines` | `Regexp` | Rails engines match to the regexp are excluded | `/^$/`
-`output_dir`      | `String` | Output JS file into the specified directory    | `Rails.root.join("app", "assets", "javascripts")`
+Name              | Type      | Description                                                                           | Default
+------------------|-----------|---------------------------------------------------------------------------------------|----------------------------------------
+`include_paths`   | `Regexp`  | Paths match to the regexp are included                                                | `/.*/`
+`exclude_paths`   | `Regexp`  | Paths match to the regexp are excluded                                                | `/^$/`
+`include_names`   | `Regexp`  | Names match to the regexp are included                                                | `/.*/`
+`exclude_names`   | `Regexp`  | Names match to the regexp are excluded                                                | `/^$/`
+`exclude_engines` | `Regexp`  | Rails engines match to the regexp are excluded                                        | `/^$/`
+`output_dir`      | `String`  | Output JS file into the specified directory                                           | `Rails.root.join("app", "assets", "javascripts")`
+`camelize`        | `Symbol`  | Output JS file with chosen camelcase type it also avaliable for `:lower` and `:upper` | `nil`
 
 You can configure via `JSRailsRoutes.configure`.
 

--- a/lib/tasks/js_rails_routes.rake
+++ b/lib/tasks/js_rails_routes.rake
@@ -9,6 +9,7 @@ namespace :js do
     generator.include_names = Regexp.new(ENV['include_names']) if ENV['include_names']
     generator.exclude_names = Regexp.new(ENV['exclude_names']) if ENV['exclude_names']
     generator.output_dir = ENV['output_dir'] if ENV['output_dir']
+    generator.camelize = ENV['camelize']&.to_sym if ENV['camelize']
     generator.generate(task)
     puts "Routes saved into #{generator.output_dir}."
   end

--- a/spec/js_rails_routes/generator_spec.rb
+++ b/spec/js_rails_routes/generator_spec.rb
@@ -150,5 +150,50 @@ RSpec.describe JSRailsRoutes::Generator do
         subject
       end
     end
+
+    shared_examples_for 'writes paths that matches expected routes' do
+      it do
+        expect(generator).to receive(:write)
+          .with(be_in(['Rails', 'Admin::Engine']), a_kind_of(String))
+          .twice do |_, arg|
+            paths = arg.split("\n")[(2 + described_class::PROCESS_FUNC.split("\n").size)..-1]
+            expect(paths).not_to be_empty
+            expect(paths).to include(match(expected_routes))
+          end
+        subject
+      end
+    end
+
+    context 'when camelize is nil' do
+      let(:expected_routes) do
+        /blog_path|note_path/
+      end
+
+      it_behaves_like 'writes paths that matches expected routes'
+    end
+
+    context 'when camelize is :lower' do
+      before do
+        generator.camelize = :lower
+      end
+
+      let(:expected_routes) do
+        /blogPath|notePath/
+      end
+
+      it_behaves_like 'writes paths that matches expected routes'
+    end
+
+    context 'when camelize is :upper' do
+      before do
+        generator.camelize = :upper
+      end
+
+      let(:expected_routes) do
+        /BlogPath|NotePath/
+      end
+
+      it_behaves_like 'writes paths that matches expected routes'
+    end
   end
 end


### PR DESCRIPTION
Many JavaScript users like to use camelcase in function name so I want to add the way to switch camelcase.

## Changes

- Added a instance variable for switching camelcase or snake_case
