### PR TITLE
Drop the support under Ruby 2.3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 Metrics/LineLength:
   Max: 120
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/js_rails_routes.gemspec
+++ b/js_rails_routes.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH << File.expand_path('lib', __dir__)
 
 require 'js_rails_routes/version'
@@ -12,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.license         = 'MIT'
   spec.files           = `git ls-files -z`.split("\x0")
   spec.require_paths   = ['lib']
+  spec.required_ruby_version = '>= 2.3.0'
+
   spec.add_dependency 'rails', '>= 3.2'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'

--- a/lib/js_rails_routes.rb
+++ b/lib/js_rails_routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'js_rails_routes/engine'
 require 'js_rails_routes/generator'
 require 'js_rails_routes/version'

--- a/lib/js_rails_routes/engine.rb
+++ b/lib/js_rails_routes/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 
 module JSRailsRoutes

--- a/lib/js_rails_routes/generator.rb
+++ b/lib/js_rails_routes/generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 module JSRailsRoutes

--- a/lib/js_rails_routes/version.rb
+++ b/lib/js_rails_routes/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JSRailsRoutes
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.0'
 end

--- a/lib/tasks/js_rails_routes.rake
+++ b/lib/tasks/js_rails_routes.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc 'Generate a ES6 module that contains Rails routes'
 namespace :js do
   task routes: :environment do |task|

--- a/spec/js_rails_routes/generator_spec.rb
+++ b/spec/js_rails_routes/generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe JSRailsRoutes::Generator do
   let(:generator) do
     described_class.clone.instance

--- a/spec/js_rails_routes_spec.rb
+++ b/spec/js_rails_routes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe JSRailsRoutes do
   describe '.configure' do
     it 'yields with Generator instance' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH << File.expand_path('../lib', __dir__)
 
 require 'simplecov'


### PR DESCRIPTION
Official support of Ruby 2.2.x has ended.

Thanks for saying okay to drop support legacy Ruby versions. https://github.com/yuku/js_rails_routes/pull/9#issuecomment-404042579