### PR TITLE
Add tests for newest teen Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: ruby
+
 rvm:
-- 2.3.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+
 notifications:
   email: false
+
 script:
-- bundle exec rake rubocop
-- bundle exec rake spec
+  - bundle exec rake rubocop
+  - bundle exec rake spec
+
 after_success:
-- bundle exec codeclimate-test-reporter
+  - bundle exec codeclimate-test-reporter


### PR DESCRIPTION
Currently, only testing `2.3.0` but the better way is to add newest each minor Ruby versions.