### PR TITLE
Add more message about `exclude_engines` to `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ## [0.7.1] - 2018-07-26
 - Refactor whole code base
 
+### Breaking Changes
+- `exclude_engines` option will check case-sensitive in strict
+
 ## [0.7.0] - 2018-07-11
 ### Added
 - Support `camelize` option


### PR DESCRIPTION
Sorry for late to send this pull-req.

I added an important message to `CHANGELOG.md`.

## why it's needed

I think users using exclude_engine with owned written regexp but currently, `exclude_engines` will check case-sensitive in strict.
So, maybe users will forget to replace the regexp.