### PR TITLE
Relax to check case-sensitive for exclude_engines

### DIFF
--- a/lib/js_rails_routes/route_set.rb
+++ b/lib/js_rails_routes/route_set.rb
@@ -40,7 +40,9 @@ module JSRailsRoutes
 
     # @return [Boolean]
     def match?
-      name !~ config.exclude_engines && routes.present?
+      return false if routes.blank?
+
+      name !~ Regexp.new(config.exclude_engines.source, Regexp::IGNORECASE)
     end
 
     private

--- a/spec/js_rails_routes/route_set_spec.rb
+++ b/spec/js_rails_routes/route_set_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe JSRailsRoutes::RouteSet do
 
         it { is_expected.to be true }
       end
+
+      context 'and it does not match to the name in a case-sensitive manner' do
+        let(:exclude_engines) { /foo/ }
+
+        it { is_expected.to be false }
+      end
     end
 
     context 'when routes are empty' do


### PR DESCRIPTION
`exclude_engines` filter will check case-sensitive in strict from `v0.7.1`.
So I want to relax checking case-sensitive.

This pull-req continues of https://github.com/yuku/js_rails_routes/pull/14#issuecomment-409765404 
plz, check it out about this problem.

cf. https://github.com/yuku/js_rails_routes/pull/14#issue-205390048